### PR TITLE
Travis: add Ruby 2.7 and 3.0, remove 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ script: "bundle exec rake spec"
 branches:
   only: master
 rvm:
-- 2.4
 - 2.5
 - 2.6
+- 2.7
+- 3.0
 gemfile:
 - gemfiles/activerecord_4.2.gemfile
 - gemfiles/activerecord_5.2.gemfile


### PR DESCRIPTION
Ruby 2.4 is EOL:
https://www.ruby-lang.org/en/downloads/

cc @grosser 