### PR TITLE
Enable comments for execute and exec query

### DIFF
--- a/lib/active_record/comments/execute_with_comments.rb
+++ b/lib/active_record/comments/execute_with_comments.rb
@@ -11,9 +11,10 @@ module ActiveRecord
                 query = ActiveRecord::Comments.with_comment_sql(query)
                 exec_query_without_comment(query, *args, &block)
               end
+            end
 
             # 99% case
-            elsif base.method_defined?(:execute)
+            if base.method_defined?(:execute)
               alias_method :execute_without_comment, :execute
               def execute(query, *args, &block)
                 query = ActiveRecord::Comments.with_comment_sql(query)

--- a/spec/active_record/comments_spec.rb
+++ b/spec/active_record/comments_spec.rb
@@ -15,6 +15,7 @@ describe ActiveRecord::Comments do
   def capture_sql
     LOG.clear
     yield
+    raise "No SQL captured" if LOG.empty?
     normalize_sql LOG.last
   end
 
@@ -105,6 +106,36 @@ describe ActiveRecord::Comments do
         sql = capture_sql { User.where(id: 1).count }
       end
       expect(sql).to eq('SELECT COUNT(*) FROM "users" WHERE "users"."id" = ? /* xxx */')
+    end
+  end
+
+  describe "arbitrary SQL via .execute" do
+    it "adds the comments to the query" do
+      captured_sql = nil
+      query = 'SELECT * FROM users where id="custom via .execute"'
+
+      ActiveRecord::Comments.comment("xxx") do
+        captured_sql = capture_sql {
+          ActiveRecord::Base.connection.execute(query)
+        }
+      end
+
+      expect(captured_sql).to eq(query + " /* xxx */")
+    end
+  end
+
+  describe "arbitrary SQL via .exec_query" do
+    it "adds the comments to the query" do
+      captured_sql = nil
+      query = 'SELECT * FROM users where id="custom via .execute"'
+
+      ActiveRecord::Comments.comment("xxx") do
+        captured_sql = capture_sql {
+          ActiveRecord::Base.connection.exec_query(query)
+        }
+      end
+
+      expect(captured_sql).to eq(query + " /* xxx */")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,12 @@ ActiveRecord::ConnectionAdapters::SQLite3Adapter.class_eval do
     LOG << query
     exec_query_without_log(query, *args, &block)
   end
+
+  alias_method :execute_without_log, :execute
+  def execute(query, *args, &block)
+    LOG << query
+    execute_without_log(query, *args, &block)
+  end
 end
 
 require "active_support/all"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,18 @@
 require "active_record"
 
+sqlite_file = "file::memory:?cache=shared"
+FileUtils.rm_f(sqlite_file)
+
 ActiveRecord::Base.establish_connection(
   :adapter => "sqlite3",
-  :database => "file::memory:?cache=shared"
+  :database => sqlite_file
 )
+
+RSpec.configure do |c|
+  c.after(:suite) do
+    FileUtils.rm_f(sqlite_file)
+  end
+end
 
 ActiveRecord::Schema.verbose = false
 ActiveRecord::Schema.define(:version => 1) do


### PR DESCRIPTION
One of our apps uses `.execute` directly for some of its reporting queries and I noticed that the gem either patches one or other.

We'd really like it if we could use both.

I also found I couldn't run the test suite more than once without manually cleaning up the file, I hope both these changes make sense.