### PR TITLE
Remove comments for execute and update README 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,19 @@ result = ActiveRecord::Comments.comment("account cleanup") do
   ActiveRecord::Comments.comment("initial") { User.where("x like y").count }
 end
 ```
+If you're using raw SQL rather than Active Record to make your query, you will need to use `exec_query` rather than `execute` for comments to be added. e.g.
+```ruby
+require 'active_record/comments'
+
+ActiveRecord::Comments.comment("My comment")
+
+sql_query = "SELECT * FROM users;"
+result = ActiveRecord::Base.connection.exec_query(sql_query)
+
+# => SELECT * FROM users /* My comment */
+```
+
+If you're replacing `execute` with `exec_query` to get comments, `exec_query.rows` returns data in the same format as `execute.entries`.
 
 Author
 ======

--- a/lib/active_record/comments/execute_with_comments.rb
+++ b/lib/active_record/comments/execute_with_comments.rb
@@ -11,10 +11,9 @@ module ActiveRecord
                 query = ActiveRecord::Comments.with_comment_sql(query)
                 exec_query_without_comment(query, *args, &block)
               end
-            end
 
             # 99% case
-            if base.method_defined?(:execute)
+            elsif base.method_defined?(:execute)
               alias_method :execute_without_comment, :execute
               def execute(query, *args, &block)
                 query = ActiveRecord::Comments.with_comment_sql(query)

--- a/spec/active_record/comments_spec.rb
+++ b/spec/active_record/comments_spec.rb
@@ -15,7 +15,6 @@ describe ActiveRecord::Comments do
   def capture_sql
     LOG.clear
     yield
-    raise "No SQL captured" if LOG.empty?
     normalize_sql LOG.last
   end
 
@@ -106,36 +105,6 @@ describe ActiveRecord::Comments do
         sql = capture_sql { User.where(id: 1).count }
       end
       expect(sql).to eq('SELECT COUNT(*) FROM "users" WHERE "users"."id" = ? /* xxx */')
-    end
-  end
-
-  describe "arbitrary SQL via .execute" do
-    it "adds the comments to the query" do
-      captured_sql = nil
-      query = 'SELECT * FROM users where id="custom via .execute"'
-
-      ActiveRecord::Comments.comment("xxx") do
-        captured_sql = capture_sql {
-          ActiveRecord::Base.connection.execute(query)
-        }
-      end
-
-      expect(captured_sql).to eq(query + " /* xxx */")
-    end
-  end
-
-  describe "arbitrary SQL via .exec_query" do
-    it "adds the comments to the query" do
-      captured_sql = nil
-      query = 'SELECT * FROM users where id="custom via .execute"'
-
-      ActiveRecord::Comments.comment("xxx") do
-        captured_sql = capture_sql {
-          ActiveRecord::Base.connection.exec_query(query)
-        }
-      end
-
-      expect(captured_sql).to eq(query + " /* xxx */")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,12 +28,6 @@ ActiveRecord::ConnectionAdapters::SQLite3Adapter.class_eval do
     LOG << query
     exec_query_without_log(query, *args, &block)
   end
-
-  alias_method :execute_without_log, :execute
-  def execute(query, *args, &block)
-    LOG << query
-    execute_without_log(query, *args, &block)
-  end
 end
 
 require "active_support/all"


### PR DESCRIPTION
Reverts @bestie's commit which introduced a breaking change for MySQL. The MySQL Adapter uses execute within exec_query which caused double-logging. This behaviour is inconsistent across adapter.  

Also updates the tests and the README to include an explanation of how to get comments when making queries using raw SQL. 