### PR TITLE
Allow the caller to optionally order comments before or after sql

### DIFF
--- a/lib/active_record/comments.rb
+++ b/lib/active_record/comments.rb
@@ -5,6 +5,12 @@ require "active_record"
 module ActiveRecord
   module Comments
     class << self
+      @@prepend = false
+
+      def prepend=prepend
+        @@prepend = prepend
+      end
+
       def comment(comment)
         current_comments << comment
         yield
@@ -14,7 +20,12 @@ module ActiveRecord
 
       def with_comment_sql(sql)
         return sql unless comment = current_comment
-        "#{sql} /* #{comment} */"
+
+        if @@prepend == true
+          "/* #{comment} */ #{sql}"
+        else
+          "#{sql} /* #{comment} */"
+        end
       end
 
       private

--- a/spec/active_record/comments_spec.rb
+++ b/spec/active_record/comments_spec.rb
@@ -100,12 +100,23 @@ describe ActiveRecord::Comments do
       expect(sql).to eq('SELECT COUNT(*) FROM "users" WHERE "users"."id" = ?')
     end
 
-    it "is there when called" do
+    it "is there when called default order" do
       sql = nil
       ActiveRecord::Comments.comment("xxx") do
         sql = capture_sql { User.where(id: 1).count }
       end
       expect(sql).to eq('SELECT COUNT(*) FROM "users" WHERE "users"."id" = ? /* xxx */')
+    end
+
+    it "is there when called prepend order" do
+      sql = nil
+      ActiveRecord::Comments.prepend = true
+      ActiveRecord::Comments.comment("xxx") do
+        sql = capture_sql { User.where(id: 1).count }
+      end
+      expect(sql).to eq('/* xxx */ SELECT COUNT(*) FROM "users" WHERE "users"."id" = ?')
+    ensure
+      ActiveRecord::Comments.prepend = false
     end
   end
 


### PR DESCRIPTION
Some databases like MySQL truncate query text when making it available for
introspection. For those using comments to pass runtime context this means any
sufficiently large SQL statements will lose not only the context but big chunks
of the query which can make debugging and tracking difficult.

Mitigate this by passing control of ordering to the caller.