### PR TITLE
Make #current_comments and #current_comment public

### DIFF
--- a/lib/active_record/comments.rb
+++ b/lib/active_record/comments.rb
@@ -28,7 +28,6 @@ module ActiveRecord
         end
       end
 
-      private
       def current_comments
         Thread.current[:ar_comments] ||= []
       end


### PR DESCRIPTION
I have a need to use ActiveRecord::Comments outside of the block-based system provided by #comment. I'm trying to correctly implement putting query comments on middleware. Using the wrapping method in that case results in deeper middlewares getting _all_ of the comments of the containing middlewares, which is a bit silly.

Instead, my middleware instrumentation code is managing comments with send(:current_comments) directly; pushing when calling a middleware, and then popping when that middleware returns & pushing again before calling the next middleware.

This means middlewares get only the comment for _that_ middleware, not all preceeding middlewares too.