### PR TITLE
Test with Ruby 3.2 & 3.3, add support for Rails 7.1, release v0.8.0

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,12 +10,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1']
         activerecord: ['5.2', '6.0', '6.1', '7.0']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
         exclude:
           - ruby: '3.0'
             activerecord: '5.2'
           - ruby: '3.1'
+            activerecord: '5.2'
+          - ruby: '3.2'
+            activerecord: '5.2'
+          - ruby: '3.3'
             activerecord: '5.2'
     name: ruby${{ matrix.ruby }} activerecord${{ matrix.activerecord }}
     env:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        activerecord: ['5.2', '6.0', '6.1', '7.0']
         ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        activerecord: ['5.2', '6.0', '6.1', '7.0', '7.1']
         exclude:
           - ruby: '3.0'
             activerecord: '5.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     active_record-comments (0.7.0)
-      activerecord (>= 5, < 7.1)
+      activerecord (>= 5, < 7.2)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_record-comments (0.7.0)
+    active_record-comments (0.8.0)
       activerecord (>= 5, < 7.2)
 
 GEM

--- a/active_record-comments.gemspec
+++ b/active_record-comments.gemspec
@@ -9,6 +9,6 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/grosser/active_record-comments"
   s.files = `git ls-files lib/ MIT-LICENSE`.split("\n")
   s.license = "MIT"
-  s.add_runtime_dependency "activerecord", ">= 5", "< 7.1"
+  s.add_runtime_dependency "activerecord", ">= 5", "< 7.2"
   s.required_ruby_version = '>= 2.7'
 end

--- a/gemfiles/activerecord_5.2.gemfile.lock
+++ b/gemfiles/activerecord_5.2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     active_record-comments (0.7.0)
-      activerecord (>= 5, < 7.1)
+      activerecord (>= 5, < 7.2)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/activerecord_5.2.gemfile.lock
+++ b/gemfiles/activerecord_5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record-comments (0.7.0)
+    active_record-comments (0.8.0)
       activerecord (>= 5, < 7.2)
 
 GEM

--- a/gemfiles/activerecord_6.0.gemfile.lock
+++ b/gemfiles/activerecord_6.0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     active_record-comments (0.7.0)
-      activerecord (>= 5, < 7.1)
+      activerecord (>= 5, < 7.2)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/activerecord_6.0.gemfile.lock
+++ b/gemfiles/activerecord_6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record-comments (0.7.0)
+    active_record-comments (0.8.0)
       activerecord (>= 5, < 7.2)
 
 GEM

--- a/gemfiles/activerecord_6.1.gemfile.lock
+++ b/gemfiles/activerecord_6.1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     active_record-comments (0.7.0)
-      activerecord (>= 5, < 7.1)
+      activerecord (>= 5, < 7.2)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/activerecord_6.1.gemfile.lock
+++ b/gemfiles/activerecord_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record-comments (0.7.0)
+    active_record-comments (0.8.0)
       activerecord (>= 5, < 7.2)
 
 GEM

--- a/gemfiles/activerecord_7.0.gemfile.lock
+++ b/gemfiles/activerecord_7.0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     active_record-comments (0.7.0)
-      activerecord (>= 5, < 7.1)
+      activerecord (>= 5, < 7.2)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/activerecord_7.0.gemfile.lock
+++ b/gemfiles/activerecord_7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record-comments (0.7.0)
+    active_record-comments (0.8.0)
       activerecord (>= 5, < 7.2)
 
 GEM

--- a/gemfiles/activerecord_7.1.gemfile
+++ b/gemfiles/activerecord_7.1.gemfile
@@ -1,0 +1,6 @@
+eval_gemfile "common.rb"
+
+gem "activerecord", "~> 7.1.0"
+gem "sqlite3", "~> 1.4"
+
+gem 'pry-byebug'

--- a/gemfiles/activerecord_7.1.gemfile.lock
+++ b/gemfiles/activerecord_7.1.gemfile.lock
@@ -1,0 +1,82 @@
+PATH
+  remote: ..
+  specs:
+    active_record-comments (0.7.0)
+      activerecord (>= 5, < 7.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (7.1.2)
+      activesupport (= 7.1.2)
+    activerecord (7.1.2)
+      activemodel (= 7.1.2)
+      activesupport (= 7.1.2)
+      timeout (>= 0.4.0)
+    activesupport (7.1.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.5)
+    bump (0.10.0)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
+    diff-lcs (1.5.0)
+    drb (2.2.0)
+      ruby2_keywords
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    method_source (1.0.0)
+    mini_portile2 (2.8.5)
+    minitest (5.21.1)
+    mutex_m (0.2.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    rake (13.1.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    ruby2_keywords (0.0.5)
+    sqlite3 (1.7.0)
+      mini_portile2 (~> 2.8.0)
+    timeout (0.4.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  active_record-comments!
+  activerecord (~> 7.1.0)
+  bump
+  pry-byebug
+  rake
+  rspec (~> 3.9)
+  sqlite3 (~> 1.4)
+
+BUNDLED WITH
+   2.4.21

--- a/gemfiles/activerecord_7.1.gemfile.lock
+++ b/gemfiles/activerecord_7.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record-comments (0.7.0)
+    active_record-comments (0.8.0)
       activerecord (>= 5, < 7.2)
 
 GEM

--- a/lib/active_record/comments/version.rb
+++ b/lib/active_record/comments/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module Comments
-    VERSION = "0.7.0"
+    VERSION = "0.8.0"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,9 +24,18 @@ LOG = []
 
 ActiveRecord::ConnectionAdapters::SQLite3Adapter.class_eval do
   alias_method :exec_query_without_log, :exec_query
-  def exec_query(query, *args, prepare: false, &block)
+  def exec_query(query, *args, **kwargs,  &block)
     LOG << query
-    exec_query_without_log(query, *args, prepare: prepare, &block)
+    exec_query_without_log(query, *args, **kwargs, &block)
+  end
+
+  # Rails 7.1.
+  if ActiveRecord::ConnectionAdapters::SQLite3Adapter.method_defined?(:internal_exec_query)
+    alias_method :internal_exec_query_without_log, :internal_exec_query
+    def internal_exec_query(query, *args, **kwargs, &block)
+      LOG << query
+      internal_exec_query_without_log(query, *args, **kwargs, &block)
+    end
   end
 end
 


### PR DESCRIPTION
1. Adds testing with Ruby 3.2 & 3.3.
2. Adds support for Rails 7.1.
3. Release v0.8.0.

**For Rails 7.1 support:**

1) Started patching `#internal_exec_query` if that method exists. `exec_query` was renamed to `internal_exec_query` in each adapter's `database_statements` in Rails 7.1: https://github.com/rails/rails/commit/942785fb8b03772dde338cc241af8e5de4d2efbc?diff=unified&w=0. The abstract `exec_query` method [calls internal_exec_query](https://github.com/rails/rails/blob/942785fb8b03772dde338cc241af8e5de4d2efbc/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L141) so I think we only need to patch `internal_exec_query`.

2) Added a kwarg splat to `exec_query`. Rails introduced an [async: false](https://github.com/rails/rails/commit/7fc174aadaefc2c0a8a6b7c8a7599dd9ca04811f) kwarg to `exec_query` which this gem wasn't respecting.