### PR TITLE
Fix compatibility with Rails edge

### DIFF
--- a/lib/active_record/comments.rb
+++ b/lib/active_record/comments.rb
@@ -39,4 +39,10 @@ module ActiveRecord
   end
 end
 
-ActiveRecord::Comments::ExecuteWithComments.install!
+if defined?(ActiveRecord::ConnectionAdapters::QueryIntent)
+  # Rails 8.2
+  ActiveRecord::ConnectionAdapters::QueryIntent.prepend(::ActiveRecord::Comments::ExecuteIntentWithComments)
+else
+  # Rails 8.1 and older
+  ActiveRecord::Comments::ExecuteWithComments.install!
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,14 +23,20 @@ end
 
 LOG = []
 
+# Rails 8.2
+if defined?(ActiveRecord::ConnectionAdapters::QueryIntent)
+  ActiveRecord::ConnectionAdapters::QueryIntent.prepend(Module.new do
+    def execute!
+      LOG << processed_sql
+      super
+    end
+  end)
+end
+
 ActiveRecord::ConnectionAdapters::SQLite3Adapter.class_eval do
   # Rails 8.2
   if defined?(ActiveRecord::ConnectionAdapters::QueryIntent)
-    alias_method :raw_execute_without_log, :raw_execute
-    def raw_execute(intent)
-      LOG << (intent.processed_sql || intent.raw_sql)
-      raw_execute_without_log(intent)
-    end
+    :see_above
   # Rails 7.1
   elsif ActiveRecord::ConnectionAdapters::SQLite3Adapter.method_defined?(:internal_exec_query)
     alias_method :internal_exec_query_without_log, :internal_exec_query


### PR DESCRIPTION
`ActiveRecord::ConnectionAdapters::QueryIntent` changed in https://github.com/rails/rails/pull/56129. I think we can now get away with just patching `QueryIntent#execute!` and not each individual database adapter.